### PR TITLE
修复空手左键空气会报错

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -81,8 +81,19 @@ public class PlantsListener implements Listener {
 
         Block b = e.getClickedBlock();
         ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+
+        // 空手不处理
+        if (item == null || item.getType().isAir() || !item.hasItemMeta()) {
+            return;
+        }
+
         final ItemMeta itemMeta = item.getItemMeta();
+        if (itemMeta == null) {
+            return;
+        }
+
         final Optional<String> id = Slimefun.getItemDataService().getItemData(itemMeta);
+
         if (b != null && id.isPresent() && id.get().equals(FluffyItems.WATERING_CAN.getItemId()) && e.getHand() == EquipmentSlot.HAND) {
             waterStructure(b.getLocation(), e, item);
         }


### PR DESCRIPTION
修复了 PlayerInteractEvent 在玩家空手右键空气时可能导致空指针异常的问题。
添加了 null 安全检查，确保 item 和 itemMeta 存在后再调用 getItemData。
